### PR TITLE
fix: HMR on the file-table package

### DIFF
--- a/packages/file-table/src/index.tsx
+++ b/packages/file-table/src/index.tsx
@@ -44,13 +44,15 @@ const createColumns = () => [
   columnHelper.display({
     id: "actions",
     header: () => <span>...</span>,
-    cell: function Cell({ row, table }) {
-      const [open, setOpen] = React.useState(false);
-
-      return <>...</>;
-    },
+    cell: Cell,
   }),
 ];
+
+function Cell({ row, table }) {
+  const [open, setOpen] = React.useState(false);
+
+  return <>...</>;
+}
 
 export function FileTable(props: {
   initialPaginationState: PaginationState;


### PR DESCRIPTION
Moving the `Cell` component outside the `columnHelper` fixes the HMR bug.